### PR TITLE
fix: accept all 2xx HTTP status codes

### DIFF
--- a/lib/codicil/llm/anthropic.ex
+++ b/lib/codicil/llm/anthropic.ex
@@ -60,7 +60,7 @@ defmodule Codicil.LLM.Anthropic do
              {"content-type", "application/json"}
            ]
          ) do
-      {:ok, %{status: 200, body: response}} ->
+      {:ok, %{status: status, body: response}} when status >= 200 and status <= 299 ->
         # Extract text from first content block
         text =
           response

--- a/lib/codicil/llm/cohere.ex
+++ b/lib/codicil/llm/cohere.ex
@@ -55,7 +55,7 @@ defmodule Codicil.LLM.Cohere do
              {"content-type", "application/json"}
            ]
          ) do
-      {:ok, %{status: 200, body: response}} ->
+      {:ok, %{status: status, body: response}} when status >= 200 and status <= 299 ->
         # Log token usage
         if meta = Map.get(response, "meta") do
           if tokens = Map.get(meta, "tokens") do
@@ -136,7 +136,7 @@ defmodule Codicil.LLM.Cohere do
              {"content-type", "application/json"}
            ]
          ) do
-      {:ok, %{status: 200, body: response}} ->
+      {:ok, %{status: status, body: response}} when status >= 200 and status <= 299 ->
         # Log token usage for embeddings
         if meta = Map.get(response, "meta") do
           if billed_units = Map.get(meta, "billed_units") do

--- a/lib/codicil/llm/google.ex
+++ b/lib/codicil/llm/google.ex
@@ -70,7 +70,7 @@ defmodule Codicil.LLM.Google do
              {"content-type", "application/json"}
            ]
          ) do
-      {:ok, %{status: 200, body: response}} ->
+      {:ok, %{status: status, body: response}} when status >= 200 and status <= 299 ->
         # Log token usage
         if usage_metadata = Map.get(response, "usageMetadata") do
           prompt_tokens = Map.get(usage_metadata, "promptTokenCount", 0)
@@ -164,7 +164,7 @@ defmodule Codicil.LLM.Google do
              {"content-type", "application/json"}
            ]
          ) do
-      {:ok, %{status: 200, body: response}} ->
+      {:ok, %{status: status, body: response}} when status >= 200 and status <= 299 ->
         {:ok, response}
 
       {:ok, %{status: status, body: body}} ->

--- a/lib/codicil/llm/grok.ex
+++ b/lib/codicil/llm/grok.ex
@@ -54,7 +54,7 @@ defmodule Codicil.LLM.Grok do
              {"content-type", "application/json"}
            ]
          ) do
-      {:ok, %{status: 200, body: response}} ->
+      {:ok, %{status: status, body: response}} when status >= 200 and status <= 299 ->
         # Extract text from first choice
         text =
           response

--- a/lib/codicil/llm/open_ai.ex
+++ b/lib/codicil/llm/open_ai.ex
@@ -66,7 +66,7 @@ defmodule Codicil.LLM.OpenAI do
            json: body,
            headers: headers
          ) do
-      {:ok, %{status: 200, body: response}} ->
+      {:ok, %{status: status, body: response}} when status >= 200 and status <= 299 ->
         # Extract text from first choice
         text =
           response
@@ -154,7 +154,7 @@ defmodule Codicil.LLM.OpenAI do
            json: body,
            headers: headers
          ) do
-      {:ok, %{status: 200, body: response}} ->
+      {:ok, %{status: status, body: response}} when status >= 200 and status <= 299 ->
         # Log token usage for embeddings
         if usage = Map.get(response, "usage") do
           total_tokens = Map.get(usage, "total_tokens", 0)

--- a/lib/codicil/llm/voyage.ex
+++ b/lib/codicil/llm/voyage.ex
@@ -75,7 +75,7 @@ defmodule Codicil.LLM.Voyage do
              {"content-type", "application/json"}
            ]
          ) do
-      {:ok, %{status: 200, body: response}} ->
+      {:ok, %{status: status, body: response}} when status >= 200 and status <= 299 ->
         {:ok, response}
 
       {:ok, %{status: status, body: body}} ->

--- a/lib/codicil/mcp.ex
+++ b/lib/codicil/mcp.ex
@@ -71,7 +71,7 @@ defmodule Codicil.MCP do
   end
 
   defp add_logger_backend() do
-    case :logger.get_handler(MCP.Logger) do
+    case :logger.get_handler_config(MCP.Logger) do
       {:ok, _} ->
         :ok
 

--- a/lib/codicil/mcp.ex
+++ b/lib/codicil/mcp.ex
@@ -75,7 +75,7 @@ defmodule Codicil.MCP do
       {:ok, _} ->
         :ok
 
-      {:error, :not_found} ->
+      {:error, {:not_found, _}} ->
         :logger.add_handler(
           MCP.Logger,
           MCP.Logger,

--- a/lib/codicil/mcp.ex
+++ b/lib/codicil/mcp.ex
@@ -71,12 +71,17 @@ defmodule Codicil.MCP do
   end
 
   defp add_logger_backend() do
-    :ok =
-      :logger.add_handler(
-        MCP.Logger,
-        MCP.Logger,
-        %{formatter: Logger.default_formatter(colors: [enabled: false])}
-      )
+    case :logger.get_handler(MCP.Logger) do
+      {:ok, _} ->
+        :ok
+
+      {:error, :not_found} ->
+        :logger.add_handler(
+          MCP.Logger,
+          MCP.Logger,
+          %{formatter: Logger.default_formatter(colors: [enabled: false])}
+        )
+    end
   end
 
   defp init_config do


### PR DESCRIPTION
Some OpenAI-compatible APIs (like Polza.ai) return HTTP 201 for successful requests instead of 200. This fix makes all LLM and embeddings clients accept any 2xx status code as success.

Changes:
- open_ai.ex: generate_text/3, make_embeddings_request/4
- voyage.ex: make_embeddings_request/2
- cohere.ex: make_chat_request/2, make_embed_request/2
- google.ex: make_generate_request/5, make_embed_request/5
- anthropic.ex: generate_text/3
- grok.ex: generate_text/3